### PR TITLE
Added missing dependency - ramsey/uuid

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
   "require": {
     "php": ">=5.3.0",
     "ext-json": "*",
-    "nesbot/carbon": "^1.2"
+    "nesbot/carbon": "^1.2",
+    "ramsey/uuid": "^3.8"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Please note, that ramsey/uuid is a PHP 7.2+ library, and therefore may not support PHP 5.3.